### PR TITLE
chore(deps): bump go version to 1.25.7

### DIFF
--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -31,9 +31,9 @@ jobs:
     steps:
       - name: Check Signature
         run: |
-          cosign verify ghcr.io/gythialy/golang-cross:1.25.6-0@sha256:5d1ac02f3cd812b783af7fef1951963ce5af87719360e24801fbfcc99d4b76d3 \
+          cosign verify ghcr.io/gythialy/golang-cross:1.25.7-0@sha256:a34c5a06e72a0c124a7c0e0da3aa0a70b14309918727148c08d1cc8bca908c9e \
           --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-          --certificate-identity "https://github.com/gythialy/golang-cross/.github/workflows/release-golang-cross.yml@refs/tags/1.25.6-0"
+          --certificate-identity "https://github.com/gythialy/golang-cross/.github/workflows/release-golang-cross.yml@refs/tags/1.25.7-0"
         env:
           TUF_ROOT: /tmp
 
@@ -43,7 +43,7 @@ jobs:
       - check-signature
 
     container:
-      image: ghcr.io/gythialy/golang-cross:1.25.6-0@sha256:5d1ac02f3cd812b783af7fef1951963ce5af87719360e24801fbfcc99d4b76d3
+      image: ghcr.io/gythialy/golang-cross:1.25.7-0@sha256:a34c5a06e72a0c124a7c0e0da3aa0a70b14309918727148c08d1cc8bca908c9e
       volumes:
         - /usr:/host_usr
         - /opt:/host_opt

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@
 
 # This is used to we scrap the go version and use in CI to get the latest go version
 # and we use dependabot to keep the go version up to date
-FROM golang:1.25.6
+FROM golang:1.25.7

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sigstore/cosign/v2
 
-go 1.25.6
+go 1.25.7
 
 require (
 	cuelang.org/go v0.14.1

--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -38,13 +38,13 @@ steps:
       - TUF_ROOT=/tmp
     args:
       - 'verify'
-      - 'ghcr.io/gythialy/golang-cross:v1.25.5-0@sha256:3a7d463d9e3438513b6bd597c79f7d5db756023e04718259cc25aabd5d00fc17'
+      - 'ghcr.io/gythialy/golang-cross:1.25.7-0@sha256:a34c5a06e72a0c124a7c0e0da3aa0a70b14309918727148c08d1cc8bca908c9e'
       - '--certificate-oidc-issuer'
       - "https://token.actions.githubusercontent.com"
       - '--certificate-identity'
-      - "https://github.com/gythialy/golang-cross/.github/workflows/release-golang-cross.yml@refs/tags/v1.25.5-0"
+      - "https://github.com/gythialy/golang-cross/.github/workflows/release-golang-cross.yml@refs/tags/1.25.7-0"
   # maybe we can build our own image and use that to be more in a safe side
-  - name: ghcr.io/gythialy/golang-cross:v1.25.5-0@sha256:3a7d463d9e3438513b6bd597c79f7d5db756023e04718259cc25aabd5d00fc17
+  - name: ghcr.io/gythialy/golang-cross:1.25.7-0@sha256:a34c5a06e72a0c124a7c0e0da3aa0a70b14309918727148c08d1cc8bca908c9e
     entrypoint: /bin/sh
     dir: "go/src/sigstore/cosign"
     env:
@@ -67,7 +67,7 @@ steps:
         gcloud auth configure-docker \
         && make release
 
-  - name: ghcr.io/gythialy/golang-cross:v1.25.5-0@sha256:3a7d463d9e3438513b6bd597c79f7d5db756023e04718259cc25aabd5d00fc17
+  - name: ghcr.io/gythialy/golang-cross:1.25.7-0@sha256:a34c5a06e72a0c124a7c0e0da3aa0a70b14309918727148c08d1cc8bca908c9e
     entrypoint: 'bash'
     dir: "go/src/sigstore/cosign"
     env:


### PR DESCRIPTION
- Update go.mod to use Go 1.25.7
- Update Dockerfile to use golang:1.25.7 base image
- Update GitHub Actions workflow to use golang-cross:1.25.7-0
- Update cloudbuild.yaml to use golang-cross:1.25.7-0 with new digest