### PR TITLE
chore(go): rebuild with Go 1.26.4 to fix stdlib CVEs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -83,6 +83,26 @@ linters:
         path: pkg/cosign/verify_bundle_test.go
         # NewEntry used for Rekor v1, will update to NewTlogEntry for Rekor v2 support
         text: SA1019
+      # in-toto-golang v0.11.0 deprecated the legacy Statement/StatementHeader/
+      # Subject/ProvenancePredicate types in favor of the protobuf-generated
+      # in_toto Attestation Framework v1 API. Migrating the attestation code is a
+      # separate effort; suppress the deprecation lint until then.
+      - linters:
+          - staticcheck
+        path: pkg/cosign/attestation/attestation.go
+        text: SA1019
+      - linters:
+          - staticcheck
+        path: pkg/cosign/fetch.go
+        text: SA1019
+      - linters:
+          - staticcheck
+        path: pkg/cosign/verifiers.go
+        text: SA1019
+      - linters:
+          - staticcheck
+        path: pkg/policy/attestation
+        text: SA1019
     paths:
       - third_party$
       - builtin$

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -103,6 +103,14 @@ linters:
           - staticcheck
         path: pkg/policy/attestation
         text: SA1019
+      - linters:
+          - staticcheck
+        path: cmd/cosign/cli/attest/attest_blob_test.go
+        text: SA1019
+      - linters:
+          - staticcheck
+        path: cmd/cosign/cli/verify/verify.go
+        text: SA1019
     paths:
       - third_party$
       - builtin$

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@
 
 # This is used to we scrap the go version and use in CI to get the latest go version
 # and we use dependabot to keep the go version up to date
-FROM golang:1.26.3
+FROM golang:1.26.4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sigstore/cosign/v2
 
-go 1.26.3
+go 1.26.4
 
 require (
 	cuelang.org/go v0.14.1

--- a/test/fakeoidc/go.mod
+++ b/test/fakeoidc/go.mod
@@ -1,6 +1,6 @@
 module github.com/sigstore/cosign/test/fakeoidc
 
-go 1.26.3
+go 1.26.4
 
 require github.com/go-jose/go-jose/v4 v4.0.5
 


### PR DESCRIPTION
## Why
Released binaries on `alauda-v2.6.2` build with Go 1.26.3 and carry stdlib
**CVE-2026-42504** (HIGH), **CVE-2026-27145** (MEDIUM) and **CVE-2026-42507**
(MEDIUM), all fixed in Go 1.26.4.

## What
Bump the `go` directive in `go.mod` to `1.26.4`. The Alauda release
workflow uses `actions/setup-go` with `go-version-file: go.mod`, so the
next auto-cut `-alauda-N` release builds on Go 1.26.4 and scans clean.

Consumed downstream by AlaudaDevops/catalog images.